### PR TITLE
fix: enable DESTRUCTOR_CLOSES_FILE flag for SdFat

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ build_flags =
   -DMINIZ_NO_STDIO=1
   -DEINK_DISPLAY_SINGLE_BUFFER_MODE=1
   -DDISABLE_FS_H_WARNING=1
+  -DDESTRUCTOR_CLOSES_FILE=1
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
@@ -90,4 +91,3 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
-  


### PR DESCRIPTION
Fork-side mirror of upstream PR for CodeRabbit review with ESP32-C3 context. See upstream crosspoint-reader/crosspoint-reader for the target PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and compiler settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->